### PR TITLE
로그인 로직 작동하지 않는 이슈 해결

### DIFF
--- a/src/main/java/com/concord/petmily/auth/dto/JwtProperties.java
+++ b/src/main/java/com/concord/petmily/auth/dto/JwtProperties.java
@@ -2,15 +2,15 @@ package com.concord.petmily.auth.dto;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Setter
 @Getter
 @Component
-@ConfigurationProperties("jwt")
 public class JwtProperties {
 
     private String issuer;
+    @Value("${spring.jwt.secret-key}")
     private String secretKey;
 }

--- a/src/main/java/com/concord/petmily/auth/dto/JwtProperties.java
+++ b/src/main/java/com/concord/petmily/auth/dto/JwtProperties.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 @Getter
 @Component
 public class JwtProperties {
-
+    @Value("${spring.jwt.issuer}")
     private String issuer;
     @Value("${spring.jwt.secret-key}")
     private String secretKey;


### PR DESCRIPTION
### 변경 사항
- [ ] 신규 기능 추가 
- [x] 버그 수정 
- [ ] 리펙토링
- [ ] 테스트 
- [ ] 문서 업데이트 
- [ ] 기타

### 작업 내역
- 작업 내역 
   로그인 로직이 동작하지 않던 문제를 해결

### 테스트
- [ ] 테스트 추가
- [ ] 모든 테스트가 통과

## 문제 및 해결
문제의 원인은 JwtProperties 에서 주입받는 `jwt-secretKey`가 원하는 값을 yml에서 찾아올수 없어서 발생한 문제 입니다.

이문제를 해결하기위해 값 주입 받을 대상에게 @Value()를 활용하여 주입받을 key 값을 지정하여  원하는 값을 주입받을 수 있도록 지정하여 해결

## 다음 진행사항

## 참고
(관련 문서, 이슈 번호 등을 여기에 링크해주세요.)
